### PR TITLE
Fix titlebar in VivalArc

### DIFF
--- a/vivaldi-vh-vivalarc.scss
+++ b/vivaldi-vh-vivalarc.scss
@@ -125,7 +125,7 @@
   }
 
   #{variables.$select-title-bar} {
-    min-height: var(--window-header) !important; // value taken from VivalArc
+    min-height: var(--win-header) !important; // value taken from VivalArc
   }
 
   #{variables.$select-address-bar}::after {
@@ -136,7 +136,7 @@
     #{variables.$select-panel},
     #{variables.$select-webpage} {
       margin-top: var(
-        --window-header
+        --win-header
       ) !important; // custom property taken from VivalArc
     }
   }


### PR DESCRIPTION
The titlebar was missing in the VivalArc version. I noticed that the VA's stylesheet uses `--win-header:calc(var(--window-border) + 4px);` but VVH was using `window-header`. Fixed by simply replacing window-header > win-header.