### PR TITLE
Fix transparent tab bar and webpage padding on Zen mode

### DIFF
--- a/EXPERIMENTAL-vivaldi-vh-addon-zenmode.scss
+++ b/EXPERIMENTAL-vivaldi-vh-addon-zenmode.scss
@@ -122,11 +122,13 @@
 
     #{variables.$select-webpage} {
       grid-column: 1 / 9999;
+      margin: var(--window-border);
     }
 
     #{variables.$select-tab-bar},
     #{variables.$select-panel} {
       position: relative;
+      background-color: var(--colorTabBar);
 
       &::after { // #tabbar-wrapper:before is already in use by the browser
         position: absolute;


### PR DESCRIPTION
This is my fix on some of the Zen mode issue with VivaldiArc. Adding the background color to the tab bar and fix the padding around the webpage. Seems working fine with me, no issues so far. 